### PR TITLE
Use the request URI as the cache key instead of the template name

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -143,6 +143,6 @@ class Module
      */
     public static function normalizeCacheKey($key)
     {
-        return str_replace(array('/', '\\', '.'), '_', $key);
+        return str_replace(array('/', '\\', '.', ':'), '_', $key);
     }
 }

--- a/src/PhlySimplePage/PageCacheListener.php
+++ b/src/PhlySimplePage/PageCacheListener.php
@@ -10,6 +10,7 @@ namespace PhlySimplePage;
 use Zend\Cache\Storage\Adapter\AbstractAdapter;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
+use Zend\Http;
 
 /**
  * Event listener implementing page level caching for pages provided by the
@@ -99,6 +100,11 @@ class PageCacheListener implements ListenerAggregateInterface
         if (!$matches) {
             return;
         }
+        
+        $request = $e->getRequest();
+        if (!$request instanceof Http\Request) {
+            return;
+        }
 
         $controller = $matches->getParam('controller');
         if ($controller != 'PhlySimplePage\Controller\Page') {
@@ -111,12 +117,7 @@ class PageCacheListener implements ListenerAggregateInterface
             return;
         }
 
-        $template = $matches->getParam('template', false);
-        if (!$template) {
-            return;
-        }
-
-        $cacheKey = Module::normalizeCacheKey($template);
+        $cacheKey = Module::normalizeCacheKey($request->getUriString());
 
         $result = $this->cache->getItem($cacheKey, $success);
         if (!$success) {


### PR DESCRIPTION
I've been using your module in an app with multiple static pages, but all of them can be internationalized.
If I enable caching, the content of the first of the languages is cached and returned for any of the other languages.
Since I set the language in the route, I changed the caching system so that the complete route is used instead of the template name, this way multiple routes with the same template can have separate cache items.
Indeed I think it makes sense to cache each resource by itself, since the route identifies each resource uniquely.

What do you think @weierophinney 